### PR TITLE
Fix "border-image fail" bug in Chrome

### DIFF
--- a/supports.js
+++ b/supports.js
@@ -10,6 +10,7 @@ var dummy = document.createElement('_'),
 document.documentElement.appendChild(style);
 dummy.setAttribute('data-foo', 'bar');
 dummy.setAttribute('data-px', '1px');
+document.documentElement.appendChild(dummy);
 
 var _ = window.Supports = {
 	prefixes: ['', '-moz-', '-webkit-', '-o-', '-ms-', 'ms-', '-khtml-'],


### PR DESCRIPTION
This is certainly a bug in Chrome, but I found a solution. Strangely if you add the variable dummy to document or do a console.log on dummy, the border-image will not fail anymore.
