### PR TITLE
Implement tests for Writing Modes

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -364,6 +364,19 @@ window.Specs = {
 		}
 	},
 	
+	"css3-writing-modes": {
+		"title": "Writing Modes",
+		"properties": {
+			"direction": ["ltr", "rtl"],
+			"unicode-bidi": ["normal", "embed", "isolate", "bidi-override", "plaintext"],
+			"writing-mode": ["horizontal-tb", "vertical-rl", "vertical-lr"],
+			"text-orientation": ["upright-right", "upright", "sideways-right", "sideways-left", "sideways", "use-glyph-orientation"],
+			"caption-side": ["before", "after"],
+			"text-combine-horizontal": ["none", "all", "digits 2", "ascii-digits 2", "alpha 2", "latin 2", "alphanumeric 2"],
+			"text-combine-mode": ["auto", "compress", "no-compress", "use-glyphs"]
+		}
+	},
+	
 	"css3-color": {
 		"title": "Color",
 		"values": {


### PR DESCRIPTION
Current stable versions of Chrome, Firefox, Opera, and Internet Explorer support direction and some or all of unicode-bidi. Internet Explorer supports the old format of writing-mode, so I imagine v10 will support the new format. Chrome supports the new format of writing mode (-webkit-writing-mode: vertical-rl | vertical-lr; works in stylesheets, unless in a <td>), but for some reason it is failing in the tests.
