### PR TITLE
Add Flexible Box Layout, Speech, and Marquee

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -445,18 +445,6 @@ window.Specs = {
 		}
 	},
 	
-	"css3-marquee": {
-		"title": "Marquee",
-		"properties": {
-			"overflow-style": ["auto", "marquee-line", "marquee-block"],
-			"marquee-style": ["scroll", "slide", "alternate"],
-			"marquee-play-count": ["0", "1", "infinite"],
-			"marquee-direction": ["forward", "reverse"],
-			"marquee-speed": ["slow", "normal", "fast"],
-			"text-combine-mode": ["auto", "compress", "no-compress", "use-glyphs"]
-		}
-	},
-	
 	"css3-speech": {
 		"title": "Speech",
 		"properties": {


### PR DESCRIPTION
All three are partially supported by either Chrome or Opera.

I believe this should complete the CSS3 modules listed at "Revising" or higher on http://www.w3.org/Style/CSS/current-work with the exception of Paged Media, which is noted as inactive.

All CSS2.1 elements not included. The speech module was particularly interesting in this, as it says the CSS2.1 Aural appendix is deprecated. I chose to still leave the few overlapping elements out.

I think IE9 has flexible box, but the syntax has been changed since its release. IE10 should pass the Flexible Box tests.
