### PR TITLE
Remove transition-duration and animation-duration's "-1s" tests

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -230,7 +230,7 @@ window.Specs = {
 		"title": "Transitions",
 		"properties": {
 			"transition-property": ["none", "all", "width", "width, height"],
-			"transition-duration": ["0s", "1s", "100ms", "-1s"],
+			"transition-duration": ["0s", "1s", "100ms"],
 			"transition-timing-function": [
 				"ease", "linear", "ease-in", "ease-out", "ease-in-out",
 				"cubic-bezier(.5, .5, .5, .5)",
@@ -246,7 +246,7 @@ window.Specs = {
 		"title": "Animations",
 		"properties": {
 			"animation-name": ["foo", "foo, bar"],
-			"animation-duration": ["0s", "1s", "100ms", "-1s"],
+			"animation-duration": ["0s", "1s", "100ms"],
 			"animation-timing-function": [
 				"ease", "linear", "ease-in", "ease-out", "ease-in-out",
 				"cubic-bezier(.5, .5, .5, .5)",


### PR DESCRIPTION
transition-duration and animation-duration's negative value tests should be removed.

Latest spec says...

> A negative value for transition-duration renders the declaration invalid.

http://dev.w3.org/csswg/css3-transitions/#transition-duration-property

> A negative ‘animation-duration’ value renders the declaration invalid.

http://dev.w3.org/csswg/css3-animations/#animation-duration-property

related: [[CSSWG] Minutes and Resolutions Telecon 2012-07-11 from fantasai on 2012-07-11 (www-style@w3.org from July 2012)](http://lists.w3.org/Archives/Public/www-style/2012Jul/0265.html)

And Mozilla Firefox 16+ follow the above spec.
[773102 – transition-duration and animation-duration should reject negative values at parse time](https://bugzilla.mozilla.org/show_bug.cgi?id=773102)

> The animation-duration and transition-duration CSS properties now reject negative values (and do not handle them as 0s anymore) (bug 773102)

[Firefox 16 for developers | MDN](https://developer.mozilla.org/en-US/docs/Firefox_16_for_developers)
