### PR TITLE
Updating tests.js with background-image property.

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -4,6 +4,7 @@ window.Specs = {
 		"properties": {
 			"background-repeat": ["space", "round"].concat(["repeat", "space", "round", "no-repeat"].times(2)),
 			"background-attachment": "local",
+			"background-image": ["url(foo.png)", "none", "inherit"],
 			"background-position": ["bottom 10px right 20px", "bottom 10px right", "top right 10px"],
 			"background-clip": ["border-box", "padding-box", "content-box"],
 			"background-origin": ["border-box", "padding-box", "content-box"],


### PR DESCRIPTION
Great work by Lea Verou with CSS3test, tests.js was missing background-image property with it's 
parameters, as (url(), none, inherit). It consists of background property, which sets all background-property in just one declaration.
Background-image property is a valid spec. as listed by w3.org ( http://www.w3.org/TR/css3-background/#the-background-image )
& w3schools.com ( http://www.w3schools.com/cssref/pr_background-image.asp ), 
review it..
