### PR TITLE
 Remove check for "min-width:auto"/"min-height:auto" as part of flexbox section, since these values were recently removed from the flexbox spec.

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -486,8 +486,6 @@ window.Specs = {
 			"flex-shrink": ["1","10"],
 			"flex-wrap": ["nowrap", "wrap", "wrap-reverse"],
 			"justify-content": ["flex-start", "flex-end", "center", "space-between", "space-around"],
-			"min-height": ["auto"],
-			"min-width": ["auto"],
 			"order": ["0", "1"],
 		}
 	}


### PR DESCRIPTION
Remove check for "min-width:auto"/"min-height:auto" as part of flexbox section, since these values were recently removed from the flexbox spec, in this spec-edit: https://dvcs.w3.org/hg/csswg/rev/9437131b3d6e
