### PR TITLE
Make index.html pass the W3C HTML5 validator

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,10 +19,10 @@
 <h1>The CSS3 test</h1>
 
 <section id="tests">
-	<hgroup>
+	<div id="hgroup">
 		<h1>Your browser scores <strong id="score">0%</strong></h1>
 		<h2>Determined by passing <strong id="passedTests"></strong> tests out of <strong id="totalTests"></strong> total for <strong id="total"></strong> features</h2>
-	</hgroup>
+	</div>
 	
 	<section id="all"></section>
 </section>
@@ -57,11 +57,11 @@
 </aside>
 
 <footer>
-	<a id="mark" href="http://lea.verou.me"><img src="http://lea.verou.me/mark.svg" title="Lea Verou was here" /></a>
+	<a id="mark" href="http://lea.verou.me"><img src="http://lea.verou.me/mark.svg" title="Lea Verou was here" alt="Lea Verou was here" /></a>
 	<p>
 		<a href="http://www.browserscope.org/user/tests/table/agt1YS1wcm9maWxlcnINCxIEVGVzdBidzawNDA" target="_blank">Results</a>
-		✿ Handcrafted by <a href="http://lea.verou.me">Lea Verou</a>
-		✿ <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=me%40leaverou%2eme&lc=GR&item_name=Lea%20Verou&currency_code=EUR&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted">Donate</a></p>
+		&#10047; Handcrafted by <a href="http://lea.verou.me">Lea Verou</a>
+		&#10047; <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&amp;business=me%40leaverou%2eme&amp;lc=GR&amp;item_name=Lea%20Verou&amp;currency_code=EUR&amp;bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted">Donate</a></p>
 </footer>
 
 <script src="utopia.js"></script>

--- a/style.css
+++ b/style.css
@@ -97,11 +97,11 @@ body > h1 {
 	margin-right: 2em;
 }
 
-	#tests hgroup {
+	#tests #hgroup {
 		text-align: center;
 	}
 	
-		#tests > hgroup > h1 {
+		#tests > #hgroup > h1 {
 			font-size: 250%;
 		}
 	


### PR DESCRIPTION
- hgroup has been removed from the HTML5 spec:
  http://lists.w3.org/Archives/Public/public-html-admin/2013Apr/0003.html
- An img element must have an alt attribute
- "&" has to be escaped as &amp; (this includes "&" in URLs!)
- Escape Unicode character
