### PR TITLE
Add Compositing and Blending Module

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -530,5 +530,14 @@ window.Specs = {
 		"properties": {
 			"all": ["initial", "inherit", "unset"]
 		}
-	}
+	},
+
+	"compositing": {
+		"title": "Compositing and Blending",
+		"properties": {
+			"mix-blend-mode": ["normal", "multiply", "screen", "overlay", "darken", "lighten", "color-dodge", "color-burn", "hard-light", "soft-light", "difference", "exclusion", "hue", "saturation", "color", "luminosity"],
+			"isolation": ["auto", "isolate"],
+			"background-blend-mode": ["normal", "multiply", "screen", "overlay", "darken", "lighten", "color-dodge", "color-burn", "hard-light", "soft-light", "difference", "exclusion", "hue", "saturation", "color", "luminosity", "normal, multiply"]
+		}
+  }
 };


### PR DESCRIPTION
`mix-blend-mode` and `background-blend-mode` properties are already implemented in Firefox Nightly builds (https://twitter.com/FirefoxNightly/status/434307807756554240). `background-blend-mode` is also implemented in latest WebKit nightly builds. 
