### PR TITLE
test the usage of viewport percentage units inside css calc function

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -442,7 +442,7 @@ window.Specs = {
 			"vmin": "5vmin",
 			"vmax": "5vmax",
 			"attr()": ["attr(data-px)", "attr(data-px px)", "attr(data-px px, initial)"],
-			"calc()": ["calc(1px + 2px)", "calc(5px*2)", "calc(5px/2)", "calc(100%/3 - 2*1em - 2*1px)", "calc(attr(data-px)*2)", "calc(5px - 10px)"],
+			"calc()": ["calc(1px + 2px)", "calc(5px*2)", "calc(5px/2)", "calc(100%/3 - 2*1em - 2*1px)", "calc(attr(data-px)*2)", "calc(5px - 10px)", "calc(1vw - 1px)"],
 			"toggle()": "toggle(1px, 2px)"
 		}
 	},


### PR DESCRIPTION
Add test for usage of viewport percentage units (vw, vh etc.) inside css calc() function.
