### PR TITLE
Removed invalid values for 'letter-spacing' and 'word-spacing'

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -303,8 +303,7 @@ window.Specs = {
 			"text-align": ["start", "end", "match-parent", "start end"],
 			"text-align-last": ["auto", "start", "end", "left", "right", "center", "justify"],
 			"text-justify": ["auto", "none", "inter-word", "distribute"],
-			"word-spacing": ["50%", "1em .5em", "1em .5em 2em", "normal 1em 2em"],
-			"letter-spacing": ["50%", "1em .5em", "1em .5em 2em", "normal 1em 2em"],
+			"word-spacing": ["50%"],
 			"text-indent": ["1em hanging", "1em each-line", "1em hanging each-line"],
 			"hanging-punctuation": ["none", "first", "last", "force-end", "allow-end", "first last"]
 		}


### PR DESCRIPTION
[According to the current draft](http://dev.w3.org/csswg/css-text/#propdef-word-spacing) `letter-spacing` and `word-spacing` do _not_ allow multiple values like `1em .5em`, `1em .5em 2em`, or `normal 1em 2em`. Furthermore `letter-spacing` does _not_ allow percentages.

So this pull request removes these values.
