### PR TITLE
Moved the 'box-decoration-break' property to the Fragmentation module

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -616,7 +616,7 @@ window.Specs = {
 			"break-after": ["any", "recto", "verso"],
 			"break-before": ["any", "recto", "verso"],
 			"break-inside": ["avoid-region"],
-            "box-decoration-break": ["slice", "clone"],
+			"box-decoration-break": ["slice", "clone"],
 			"orphans": ["1", "2"],
 			"widows": ["1", "2"]
 		}


### PR DESCRIPTION
The `box-decoration-break` property has moved to the [CSS Fragmentation Module](http://dev.w3.org/csswg/css3-break/).
