### PR TITLE
Add CSS Will Change Module Level 1

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -629,5 +629,12 @@ window.Specs = {
 		"properties": {
 			"position": ["sticky"]
 		}
-	}
+	},
+
+    "css-will-change": {
+        "title": "Will Change",
+        "properties": {
+            "will-change": ["scroll-position", "contents", "transform", "top, left"]
+        }
+    }
 };


### PR DESCRIPTION
Add CSS Will Change Module Level 1. Shipped in Chrome 36 and enabled in Firefox Nightly.

ED: http://dev.w3.org/csswg/css-will-change/
